### PR TITLE
Remove deprecated signed yaml verification

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,11 +86,6 @@ func main() {
 			Usage:  "use path style for bucket paths",
 			EnvVar: "PLUGIN_PATH_STYLE",
 		},
-		cli.BoolTFlag{
-			Name:   "yaml-verified",
-			Usage:  "Ensure the yaml was signed",
-			EnvVar: "DRONE_YAML_VERIFIED",
-		},
 		cli.StringFlag{
 			Name:  "env-file",
 			Usage: "source env file",
@@ -108,20 +103,19 @@ func run(c *cli.Context) error {
 	}
 
 	plugin := Plugin{
-		Endpoint:     c.String("endpoint"),
-		Key:          c.String("access-key"),
-		Secret:       c.String("secret-key"),
-		Bucket:       c.String("bucket"),
-		Region:       c.String("region"),
-		Access:       c.String("acl"),
-		Source:       c.String("source"),
-		Target:       c.String("target"),
-		StripPrefix:  c.String("strip-prefix"),
-		Exclude:      c.StringSlice("exclude"),
-		Encryption:   c.String("encryption"),
-		PathStyle:    c.Bool("path-style"),
-		DryRun:       c.Bool("dry-run"),
-		YamlVerified: c.BoolT("yaml-verified"),
+		Endpoint:    c.String("endpoint"),
+		Key:         c.String("access-key"),
+		Secret:      c.String("secret-key"),
+		Bucket:      c.String("bucket"),
+		Region:      c.String("region"),
+		Access:      c.String("acl"),
+		Source:      c.String("source"),
+		Target:      c.String("target"),
+		StripPrefix: c.String("strip-prefix"),
+		Exclude:     c.StringSlice("exclude"),
+		Encryption:  c.String("encryption"),
+		PathStyle:   c.Bool("path-style"),
+		DryRun:      c.Bool("dry-run"),
 	}
 
 	return plugin.Exec()

--- a/plugin.go
+++ b/plugin.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"errors"
 	log "github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -63,8 +62,6 @@ type Plugin struct {
 	// Strip the prefix from the target path
 	StripPrefix string
 
-	YamlVerified bool
-
 	// Exclude files matching this pattern.
 	Exclude []string
 
@@ -94,8 +91,6 @@ func (p *Plugin) Exec() error {
 	//Allowing to use the instance role or provide a key and secret
 	if p.Key != "" && p.Secret != "" {
 		conf.Credentials = credentials.NewStaticCredentials(p.Key, p.Secret, "")
-	} else if p.YamlVerified != true {
-		return errors.New("Security issue: When using instance role you must have the yaml verified")
 	}
 	client := s3.New(session.New(), conf)
 


### PR DESCRIPTION
As of Drone 0.7 the signed yaml verification is deprecated, so we shouldn't need to check for it when using IAM roles.